### PR TITLE
Handle transaction prices syntax

### DIFF
--- a/syntax/journal.vim
+++ b/syntax/journal.vim
@@ -36,18 +36,21 @@ syntax match patternAmountType1 '\v[^-0-9 \t]+' contained nextgroup=patternAmoun
 syntax match patternAmountType1 '\v"[^"]*"' contained nextgroup=patternAmountQuantity2 skipwhite
 highlight link patternAmountType1 Type
 
-syntax match patternAmountType2 '\v[^-0-9 \t]+' contained nextgroup=patternAssertionEq skipwhite
-syntax match patternAmountType2 '\v"[^"]*"' contained nextgroup=patternAssertionEq skipwhite
+syntax match patternAmountType2 '\v[^-0-9 \t]+' contained nextgroup=patternAssertionEq,patternAmountPriceAt skipwhite
+syntax match patternAmountType2 '\v"[^"]*"' contained nextgroup=patternAssertionEq,patternAmountPriceAt skipwhite
 highlight link patternAmountType2 Type
 
 syntax match patternAmountMinus '-' contained nextgroup=patternAmountType1
 highlight link patternAmountMinus Number
 
-syntax match patternAmountQuantity1 '\v-?\d+([ ,.]\d+)*(\.\d+)?' contained nextgroup=patternAmountType2,patternAssertionEq skipwhite
+syntax match patternAmountQuantity1 '\v-?\d+([ ,.]\d+)*(\.\d+)?' contained nextgroup=patternAmountType2,patternAssertionEq,patternAmountPriceAt skipwhite
 highlight link patternAmountQuantity1 Number
 
-syntax match patternAmountQuantity2 '\v-?\d+([ ,.]\d+)*(\.\d+)?' contained nextgroup=patternAssertionEq skipwhite
+syntax match patternAmountQuantity2 '\v-?\d+([ ,.]\d+)*(\.\d+)?' contained nextgroup=patternAssertionEq,patternAmountPriceAt skipwhite
 highlight link patternAmountQuantity2 Number
+
+syntax match patternAmountPriceAt '\v\@\@?' contained nextgroup=patternAmountMinus,patternAmountType1,patternAmountQuantity1 skipwhite
+highlight link patternAmountPriceAt Operator
 
 syntax match patternAssertionEq '\v\=\=?\*?' contained nextgroup=patternAssertionMinus,patternAssertionType1,patternAssertionQuantity1 skipwhite
 highlight link patternAssertionEq Operator


### PR DESCRIPTION
Hi Eric,

This is a simple PR to add support for transaction prices, which I regularly use when dealing with multiple currencies (see <https://hledger.org/journal.html#transaction-prices>). There are two ways of recording transaction prices, either based on the unit price (example from the documentation):

```ledger
2009/1/1
  assets:euros     €100 @ $1.35  ; one hundred euros purchased at $1.35 each
  assets:dollars                 ; balancing amount is -$135.00
```

in which case a single at-sign is used, or by writing the total price

```ledger
2009/1/1
  assets:euros     €100 @@ $135  ; one hundred euros purchased at $135 for the lot
  assets:dollars
```

in which case two at-signs are used.

I’m not too experienced with Vim syntax files but I tried my best not to mess anything up!

Thank you for your time.